### PR TITLE
Get base_url from config rather than hardcoded string

### DIFF
--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -13,10 +13,13 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 class DBTStream(RESTStream):
     """dbt stream class."""
 
-    url_base = "https://cloud.getdbt.com/api/v2"
     primary_keys = ["id"]
     replication_key = None
     response_jsonpath = "$.data[*]"
+
+    @property
+    def url_base(self):
+        return self.config.get('base_url', 'https://cloud.getdbt.com/api/v2')
 
     @property
     def http_headers(self) -> dict:

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -19,7 +19,7 @@ class DBTStream(RESTStream):
 
     @property
     def url_base(self):
-        return self.config.get('base_url', 'https://cloud.getdbt.com/api/v2')
+        return self.config.get("base_url", "https://cloud.getdbt.com/api/v2")
 
     @property
     def http_headers(self) -> dict:


### PR DESCRIPTION
Although the config allows a base_url, this is not used in the stream but is rather hardcoded. We are on a single-tenant, and notice when this setting is not configurable.