### PR TITLE
refactor: Working pagination using the "extra" fields and the `has_more` method

### DIFF
--- a/.github/workflows/test-tap.yml
+++ b/.github/workflows/test-tap.yml
@@ -1,6 +1,9 @@
 name: Test Tap
 
-on: push
+on:
+  pull_request: {}
+  push:
+    branches: [main]
 
 jobs:
   test_tap:

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -63,7 +63,7 @@ class AccountBasedStream(DBTStream):
         """Return a new paginator instance for this stream."""
         return DbtPaginator(start_value=0, page_size=100)
 
-    def get_url_params(self, context, next_page_token: int) -> dict:
+    def get_url_params(self, context: dict, next_page_token: int) -> dict:
         """Return offset as the next page token"""
         params = {}
 

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -19,7 +19,7 @@ class DbtPaginator(BaseOffsetPaginator):
     """dbt API paginator."""
 
     def has_more(self, response: requests.Response) -> bool:
-        """ Returns True until there are no more pages to retrieve.
+        """Returns True until there are no more pages to retrieve.
         
         The API returns an 'extra' key with information about pagination:
         "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}} 

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -17,22 +17,27 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class DbtPaginator(BaseOffsetPaginator):
     """dbt API paginator."""
-    """
-    The API returns an 'extra' key with information about pagination:
-    "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}}
-    """
-    def has_more(self, response):
+
+    def has_more(self, response) -> bool:
+        """
+        Returns True until there are no more pages to retrieve
+        
+        The API returns an 'extra' key with information about pagination:
+        "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}} 
+        """
         data = response.json()
         extra = data.get("extra")
         filters = extra.get("filters")
         pagination = extra.get("pagination")
         
-        limit = filters.get("limit")
         offset = filters.get("offset",0)
         total_count = pagination.get("total_count")
         count = pagination.get("count")
         
-        """The pagination has more records when total_count is still greater than count and offset combined"""
+        """
+        The pagination has more records when:
+        total_count is still greater than count and offset combined
+        """
         return (count + offset < total_count)
 
 class AccountBasedStream(DBTStream):
@@ -58,7 +63,8 @@ class AccountBasedStream(DBTStream):
         """Return a new paginator instance for this stream."""
         return DbtPaginator(start_value=0, page_size=100)
 
-    def get_url_params(self, context, next_page_token):
+    def get_url_params(self, next_page_token: int) -> dict:
+        """Return offset as the next page token"""
         params = {}
 
         # Next page token is an offset

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -64,10 +64,11 @@ class AccountBasedStream(DBTStream):
         return DbtPaginator(start_value=0, page_size=100)
 
     def get_url_params(
-        self, context: dict, next_page_token: int  # pylint: disable=unused-argument
+        self, context: dict, next_page_token: int,
     ) -> dict:
         """Return offset as the next page token."""
         params = {}
+        _ = context
 
         # Next page token is an offset
         if next_page_token:

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -17,31 +17,23 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class DbtPaginator(BaseOffsetPaginator):
     """dbt API paginator."""
-
-    def get_next(self, response: requests.Response) -> int | None:
-        """Return the next page number, or None if there are no more pages.
-
-        Args:
-            response: The response object from the previous request.
-
-        Returns:
-            The next page number, or None if there are no more pages.
-        """
+    """
+    The API returns an 'extra' key with information about pagination:
+    "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}}
+    """
+    def has_more(self, response):
         data = response.json()
-
-        if len(data["data"]):
-            return self._value + self._page_size
-
-        return None
-
-
-class PaginationMixin:
-    """A mixin for streams that use the dbt API pagination mechanism."""
-
-    def get_new_paginator(self) -> DbtPaginator:
-        """Return a new paginator instance for this stream."""
-        return DbtPaginator(start_value=0, page_size=100)
-
+        extra = data.get("extra")
+        filters = extra.get("filters")
+        pagination = extra.get("pagination")
+        
+        limit = filters.get("limit")
+        offset = filters.get("offset",0)
+        total_count = pagination.get("total_count")
+        count = pagination.get("count")
+        
+        """The pagination has more records when total_count is still greater than count and offset combined"""
+        return (count + offset < total_count)
 
 class AccountBasedStream(DBTStream):
     """A stream that requires an account ID."""
@@ -61,43 +53,38 @@ class AccountBasedStream(DBTStream):
             "Expected a URL path containing '{account_id}'. "
         )
         raise ValueError(errmsg)
+      
+    def get_new_paginator(self) -> DbtPaginator:
+        """Return a new paginator instance for this stream."""
+        return DbtPaginator(start_value=0, page_size=100)
+
+    def get_url_params(self, context, next_page_token):
+        params = {}
+
+        # Next page token is an offset
+        if next_page_token:
+            params["offset"] = next_page_token
+
+        return params
 
 
-class AccountsStream(AccountBasedStream):
+class AccountsStream(DBTStream):
     """A stream for the accounts endpoint."""
 
     name = "accounts"
-    path = "/accounts/{account_id}"
+    path = "/accounts"
     schema_filepath = SCHEMAS_DIR / "accounts.json"
     records_jsonpath = "$.data"
     openapi_ref = "Account"
 
-
-class JobsStream(AccountBasedStream, PaginationMixin):
+class JobsStream(AccountBasedStream):
     """A stream for the jobs endpoint."""
 
     name = "jobs"
     path = "/accounts/{account_id}/jobs"
     openapi_ref = "Job"
 
-    def get_url_params(
-        self,
-        context: dict | None,  # noqa: ARG002
-        next_page_token: int,  # noqa: ARG002
-    ) -> dict[str, t.Any]:
-        """Return a dictionary of values to be used in URL parameterization.
-
-        Args:
-            context: Stream context.
-            next_page_token: The next page token.
-
-        Returns:
-            A dictionary of values to be used as URL query parameters.
-        """
-        return {"order_by": "updated_at"}
-
-
-class ProjectsStream(AccountBasedStream, PaginationMixin):
+class ProjectsStream(AccountBasedStream):
     """A stream for the projects endpoint."""
 
     name = "projects"
@@ -105,22 +92,10 @@ class ProjectsStream(AccountBasedStream, PaginationMixin):
     openapi_ref = "Project"
 
 
-class RunsStream(AccountBasedStream, PaginationMixin):
+class RunsStream(AccountBasedStream):
     """A stream for the runs endpoint."""
 
     name = "runs"
     path = "/accounts/{account_id}/runs"
     openapi_ref = "Run"
     page_size = 100
-
-    def get_url_params(
-        self,
-        context: dict | None,  # noqa: ARG002
-        next_page_token: int,
-    ) -> dict[str, t.Any]:
-        """Return a dictionary of values to be used in URL parameterization."""
-        return {
-            "order_by": "updated_at",
-            "limit": self.page_size,
-            "offset": next_page_token,
-        }

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -64,7 +64,9 @@ class AccountBasedStream(DBTStream):
         return DbtPaginator(start_value=0, page_size=100)
 
     def get_url_params(
-        self, context: dict, next_page_token: int,
+        self,
+        context: dict,
+        next_page_token: int,
     ) -> dict:
         """Return offset as the next page token."""
         params = {}

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -18,9 +18,8 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 class DbtPaginator(BaseOffsetPaginator):
     """dbt API paginator."""
 
-    def has_more(self, response) -> bool:
-        """
-        Returns True until there are no more pages to retrieve
+    def has_more(self, response: requests.Response) -> bool:
+        """ Returns True until there are no more pages to retrieve.
         
         The API returns an 'extra' key with information about pagination:
         "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}} 
@@ -64,7 +63,7 @@ class AccountBasedStream(DBTStream):
         return DbtPaginator(start_value=0, page_size=100)
 
     def get_url_params(self, context: dict, next_page_token: int) -> dict:
-        """Return offset as the next page token"""
+        """Return offset as the next page token."""
         params = {}
 
         # Next page token is an offset

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -63,7 +63,7 @@ class AccountBasedStream(DBTStream):
         """Return a new paginator instance for this stream."""
         return DbtPaginator(start_value=0, page_size=100)
 
-    def get_url_params(self, next_page_token: int) -> dict:
+    def get_url_params(self, context, next_page_token: int) -> dict:
         """Return offset as the next page token"""
         params = {}
 

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -20,24 +20,25 @@ class DbtPaginator(BaseOffsetPaginator):
 
     def has_more(self, response: requests.Response) -> bool:
         """Returns True until there are no more pages to retrieve.
-        
+
         The API returns an 'extra' key with information about pagination:
-        "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}} 
+        "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}}
         """
         data = response.json()
         extra = data.get("extra")
         filters = extra.get("filters")
         pagination = extra.get("pagination")
-        
-        offset = filters.get("offset",0)
+
+        offset = filters.get("offset", 0)
         total_count = pagination.get("total_count")
         count = pagination.get("count")
-        
+
         """
         The pagination has more records when:
         total_count is still greater than count and offset combined
         """
-        return (count + offset < total_count)
+        return count + offset < total_count
+
 
 class AccountBasedStream(DBTStream):
     """A stream that requires an account ID."""
@@ -57,15 +58,13 @@ class AccountBasedStream(DBTStream):
             "Expected a URL path containing '{account_id}'. "
         )
         raise ValueError(errmsg)
-      
+
     def get_new_paginator(self) -> DbtPaginator:
         """Return a new paginator instance for this stream."""
         return DbtPaginator(start_value=0, page_size=100)
 
     def get_url_params(
-            self, 
-            context: dict, # pylint: disable=unused-argument
-            next_page_token: int
+        self, context: dict, next_page_token: int  # pylint: disable=unused-argument
     ) -> dict:
         """Return offset as the next page token."""
         params = {}
@@ -86,12 +85,14 @@ class AccountsStream(DBTStream):
     records_jsonpath = "$.data"
     openapi_ref = "Account"
 
+
 class JobsStream(AccountBasedStream):
     """A stream for the jobs endpoint."""
 
     name = "jobs"
     path = "/accounts/{account_id}/jobs"
     openapi_ref = "Job"
+
 
 class ProjectsStream(AccountBasedStream):
     """A stream for the projects endpoint."""

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -25,18 +25,16 @@ class DbtPaginator(BaseOffsetPaginator):
         "extra":{"filters":{"limit":100,"offset":2,"account_id":1},"order_by":"id","pagination":{"count":100,"total_count":209}}}
         """
         data = response.json()
-        extra = data.get("extra")
-        filters = extra.get("filters")
-        pagination = extra.get("pagination")
+        extra = data.get("extra", {})
+        filters = extra.get("filters", {})
+        pagination = extra.get("pagination", {})
 
         offset = filters.get("offset", 0)
         total_count = pagination.get("total_count")
         count = pagination.get("count")
 
-        """
-        The pagination has more records when:
-        total_count is still greater than count and offset combined
-        """
+        # The pagination has more records when:
+        # total_count is still greater than count and offset combined
         return count + offset < total_count
 
 
@@ -85,7 +83,6 @@ class AccountsStream(DBTStream):
     name = "accounts"
     path = "/accounts"
     schema_filepath = SCHEMAS_DIR / "accounts.json"
-    records_jsonpath = "$.data"
     openapi_ref = "Account"
 
 

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -62,7 +62,11 @@ class AccountBasedStream(DBTStream):
         """Return a new paginator instance for this stream."""
         return DbtPaginator(start_value=0, page_size=100)
 
-    def get_url_params(self, context: dict, next_page_token: int) -> dict:
+    def get_url_params(
+            self, 
+            context: dict, # pylint: disable=unused-argument
+            next_page_token: int
+    ) -> dict:
         """Return offset as the next page token."""
         params = {}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,88 +32,89 @@ def accounts_response(fake: Faker):
             "code": 200,
             "is_success": True,
         },
-        "data": {
-            "id": 1000,
-            "name": fake.company(),
-        },
+        "data": [
+            {
+                "id": 1000,
+                "name": fake.company(),
+            },
+        ],
+        "extra": {},
     }
 
 
 @pytest.fixture()
 def projects_response():
     """Return a sample response for the projects stream."""
-    return [
-        {
-            "status": {
-                "code": 200,
-                "is_success": True,
-            },
-            "data": [
-                {
-                    "id": 1000 + i,
-                    "account_id": 1000,
-                }
-                for i in range(10)
-            ],
+    return {
+        "status": {
+            "code": 200,
+            "is_success": True,
         },
-    ]
+        "data": [
+            {
+                "id": 1000 + i,
+                "account_id": 1000,
+            }
+            for i in range(10)
+        ],
+        "extra": {},
+    }
 
 
 @pytest.fixture()
 def jobs_response(fake: Faker):
     """Return a sample response for the jobs stream."""
-    return [
-        {
-            "status": {
-                "code": 200,
-                "is_success": True,
-            },
-            "data": [
-                {
-                    "id": 1000 + i,
-                    "account_id": 1000,
-                    "project_id": 1000 + i % 3,
-                    "environment_id": 1000,
-                    "dbt_version": "1.4.0",
-                    "name": fake.bs(),
-                    "execute_steps": [
-                        "dbt deps",
-                        "dbt seed",
-                        "dbt run",
-                    ],
-                    "state": fake.random_element([1, 2]),
-                    "triggers": {
-                        "github_webhook": True,
-                        "schedule": False,
-                    },
-                    "settings": {
-                        "threads": 5,
-                        "target_name": "prod",
-                    },
-                    "schedule": {
-                        "date": {
-                            "type": fake.random_element(
-                                [
-                                    "every_day",
-                                    "days_of_week",
-                                    "custom_cron",
-                                ],
-                            ),
-                        },
-                        "time": {
-                            "type": fake.random_element(
-                                [
-                                    "every_hour",
-                                    "at_exact_hours",
-                                ],
-                            ),
-                        },
-                    },
-                }
-                for i in range(10)
-            ],
+    return {
+        "status": {
+            "code": 200,
+            "is_success": True,
         },
-    ]
+        "extra": {},
+        "data": [
+            {
+                "id": 1000 + i,
+                "account_id": 1000,
+                "project_id": 1000 + i % 3,
+                "environment_id": 1000,
+                "dbt_version": "1.4.0",
+                "name": fake.bs(),
+                "execute_steps": [
+                    "dbt deps",
+                    "dbt seed",
+                    "dbt run",
+                ],
+                "state": fake.random_element([1, 2]),
+                "triggers": {
+                    "github_webhook": True,
+                    "schedule": False,
+                },
+                "settings": {
+                    "threads": 5,
+                    "target_name": "prod",
+                },
+                "schedule": {
+                    "date": {
+                        "type": fake.random_element(
+                            [
+                                "every_day",
+                                "days_of_week",
+                                "custom_cron",
+                            ],
+                        ),
+                    },
+                    "time": {
+                        "type": fake.random_element(
+                            [
+                                "every_hour",
+                                "at_exact_hours",
+                            ],
+                        ),
+                    },
+                },
+            }
+            for i in range(10)
+        ],
+    }
 
 
 @pytest.fixture()
@@ -124,6 +125,7 @@ def runs_response():
             "code": 200,
             "is_success": True,
         },
+        "extra": {},
         "data": [
             {
                 "id": 1000 + i,
@@ -148,7 +150,7 @@ def test_standard_tap_tests(
 
     responses.add(
         responses.GET,
-        "https://cloud.getdbt.com/api/v2/accounts/1000",
+        "https://cloud.getdbt.com/api/v2/accounts",
         json=accounts_response,
         status=200,
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,7 +38,18 @@ def accounts_response(fake: Faker):
                 "name": fake.company(),
             },
         ],
-        "extra": {},
+      "extra": {
+        "filters": {
+          "pk__in": [
+            1
+          ]
+        },
+        "order_by": null,
+        "pagination": {
+          "count": 1,
+          "total_count": 1
+        }
+      }
     }
 
 
@@ -57,7 +68,18 @@ def projects_response():
             }
             for i in range(10)
         ],
-        "extra": {},
+      "extra": {
+        "filters": {
+          "account_id": 1,
+          "limit": 1,
+          "offset": 0
+        },
+        "order_by": "id",
+        "pagination": {
+          "count": 1,
+          "total_count": 2
+        }
+      }
     }
 
 
@@ -69,7 +91,18 @@ def jobs_response(fake: Faker):
             "code": 200,
             "is_success": True,
         },
-        "extra": {},
+          "extra": {
+            "filters": {
+              "limit": 1,
+              "offset": 0,
+              "account_id": 1
+            },
+            "order_by": "id",
+            "pagination": {
+              "count": 1,
+              "total_count": 300
+            }
+          }
         "data": [
             {
                 "id": 1000 + i,
@@ -125,7 +158,18 @@ def runs_response():
             "code": 200,
             "is_success": True,
         },
-        "extra": {},
+          "extra": {
+            "filters": {
+              "account_id": 1,
+              "limit": 1,
+              "offset": 0
+            },
+            "order_by": "id",
+            "pagination": {
+              "count": 1,
+              "total_count": 500000
+            }
+          }
         "data": [
             {
                 "id": 1000 + i,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,15 +41,15 @@ def accounts_response(fake: Faker):
       "extra": {
         "filters": {
           "pk__in": [
-            1
+            1,
           ]
         },
         "order_by": null,
         "pagination": {
           "count": 1,
-          "total_count": 1
-        }
-      }
+          "total_count": 1,
+        },
+      },
     }
 
 
@@ -72,14 +72,14 @@ def projects_response():
         "filters": {
           "account_id": 1,
           "limit": 1,
-          "offset": 0
+          "offset": 0,
         },
         "order_by": "id",
         "pagination": {
           "count": 1,
-          "total_count": 2
-        }
-      }
+          "total_count": 2,
+        },
+      },
     }
 
 
@@ -95,14 +95,14 @@ def jobs_response(fake: Faker):
             "filters": {
               "limit": 1,
               "offset": 0,
-              "account_id": 1
+              "account_id": 1,
             },
             "order_by": "id",
             "pagination": {
               "count": 1,
-              "total_count": 300
-            }
-          }
+              "total_count": 300,
+            },
+          },
         "data": [
             {
                 "id": 1000 + i,
@@ -162,14 +162,14 @@ def runs_response():
             "filters": {
               "account_id": 1,
               "limit": 1,
-              "offset": 0
+              "offset": 0,
             },
             "order_by": "id",
             "pagination": {
               "count": 1,
-              "total_count": 500000
-            }
-          }
+              "total_count": 500000,
+            },
+          },
         "data": [
             {
                 "id": 1000 + i,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,9 +42,9 @@ def accounts_response(fake: Faker):
         "filters": {
           "pk__in": [
             1,
-          ]
+          ],
         },
-        "order_by": null,
+        "order_by": None,
         "pagination": {
           "count": 1,
           "total_count": 1,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,18 +38,18 @@ def accounts_response(fake: Faker):
                 "name": fake.company(),
             },
         ],
-      "extra": {
-        "filters": {
-          "pk__in": [
-            1,
-          ],
+        "extra": {
+            "filters": {
+                "pk__in": [
+                    1,
+                ],
+            },
+            "order_by": None,
+            "pagination": {
+                "count": 1,
+                "total_count": 1,
+            },
         },
-        "order_by": None,
-        "pagination": {
-          "count": 1,
-          "total_count": 1,
-        },
-      },
     }
 
 
@@ -68,18 +68,18 @@ def projects_response():
             }
             for i in range(10)
         ],
-      "extra": {
-        "filters": {
-          "account_id": 1,
-          "limit": 1,
-          "offset": 0,
+        "extra": {
+            "filters": {
+                "account_id": 1,
+                "limit": 1,
+                "offset": 0,
+            },
+            "order_by": "id",
+            "pagination": {
+                "count": 1,
+                "total_count": 2,
+            },
         },
-        "order_by": "id",
-        "pagination": {
-          "count": 1,
-          "total_count": 2,
-        },
-      },
     }
 
 
@@ -91,18 +91,18 @@ def jobs_response(fake: Faker):
             "code": 200,
             "is_success": True,
         },
-          "extra": {
+        "extra": {
             "filters": {
-              "limit": 1,
-              "offset": 0,
-              "account_id": 1,
+                "limit": 1,
+                "offset": 0,
+                "account_id": 1,
             },
             "order_by": "id",
             "pagination": {
-              "count": 1,
-              "total_count": 300,
+                "count": 1,
+                "total_count": 300,
             },
-          },
+        },
         "data": [
             {
                 "id": 1000 + i,
@@ -158,18 +158,18 @@ def runs_response():
             "code": 200,
             "is_success": True,
         },
-          "extra": {
+        "extra": {
             "filters": {
-              "account_id": 1,
-              "limit": 1,
-              "offset": 0,
+                "account_id": 1,
+                "limit": 1,
+                "offset": 0,
             },
             "order_by": "id",
             "pagination": {
-              "count": 1,
-              "total_count": 500000,
+                "count": 1,
+                "total_count": 500000,
             },
-          },
+        },
         "data": [
             {
                 "id": 1000 + i,


### PR DESCRIPTION
# Background
Open to review/suggestions. I found that I couldn't get any more than 100 jobs (there are 206 in our environment), so I decided to investigate getting the new `BaseOffsetPaginator` to work. I could see you've already implemented it, thanks @edgarrmondragon!

# Changes
I have simplified the code a bit, I don't know much about using `Mixin` classes, but I noticed that pagination could be used on any `AccountBasedStream` so I just added the pagination logic into that class and then subclassed that for each endpoint. I couldn't get this to work if I kept the Mixin there unfortunately.

The `accounts` endpoint doesn't take an account_id/partitioning, so I simply subclassed that stream endpoint from the base `DBTStream` class.

The `has_more` method goes to the `"extra"` element in the response, which often looks like this:

```json
{
    "extra": {
        "filters": {
            "limit": 100,
            "offset": 200,
            "account_id": 1
        },
        "order_by": "id",
        "pagination": {
            "count": 9,
            "total_count": 209
        }
    }
}
```

has_more returns `True` when there are still pages to get, so I set the conditional to be (count + offset < total_count), i.e. the pagination has more records when `total_count` is still greater than `count` and `offset` combined. The example above shows a situation where no further pages are obtainable:

```python
count=9
offset=200
total_count=209
```
