### PR TITLE
fix: post process openapi schema to allow null types

### DIFF
--- a/tap_dbt/client.py
+++ b/tap_dbt/client.py
@@ -72,15 +72,13 @@ class DBTStream(RESTStream):
             The schema for this stream.
         """
         openapi_response = self._resolve_openapi_ref()
-        # Append "null" to types in all properties if "nullable" key is present
-        for property_name, property_schema in openapi_response["properties"].items():
+        
+        for property_schema in openapi_response["properties"].values():
             if property_schema.get("nullable"):
                 if isinstance(property_schema["type"], list):
                     property_schema["type"].append("null")
                 else:
                     property_schema["type"] = [property_schema["type"], "null"]
-
-        print(openapi_response["properties"])
 
         return openapi_response
 

--- a/tap_dbt/client.py
+++ b/tap_dbt/client.py
@@ -73,16 +73,15 @@ class DBTStream(RESTStream):
         """
         openapi_response = self._resolve_openapi_ref()
         # Append "null" to types in all properties if "nullable" key is present
-        for property_name, property_schema in openapi_response['properties'].items():
+        for property_name, property_schema in openapi_response["properties"].items():
             if property_schema.get("nullable"):
-                if isinstance(property_schema["type"],list):
+                if isinstance(property_schema["type"], list):
                     property_schema["type"].append("null")
                 else:
                     property_schema["type"] = [property_schema["type"], "null"]
-                  
-        
-        print(openapi_response['properties'])
-        
+
+        print(openapi_response["properties"])
+
         return openapi_response
 
     @property

--- a/tap_dbt/client.py
+++ b/tap_dbt/client.py
@@ -71,7 +71,19 @@ class DBTStream(RESTStream):
         Returns:
             The schema for this stream.
         """
-        return self._resolve_openapi_ref()
+        openapi_response = self._resolve_openapi_ref()
+        # Append "null" to types in all properties if "nullable" key is present
+        for property_name, property_schema in openapi_response['properties'].items():
+            if property_schema.get("nullable"):
+                if isinstance(property_schema["type"],list):
+                    property_schema["type"].append("null")
+                else:
+                    property_schema["type"] = [property_schema["type"], "null"]
+                  
+        
+        print(openapi_response['properties'])
+        
+        return openapi_response
 
     @property
     @abstractmethod

--- a/tap_dbt/client.py
+++ b/tap_dbt/client.py
@@ -72,7 +72,7 @@ class DBTStream(RESTStream):
             The schema for this stream.
         """
         openapi_response = self._resolve_openapi_ref()
-        
+
         for property_schema in openapi_response["properties"].values():
             if property_schema.get("nullable"):
                 if isinstance(property_schema["type"], list):


### PR DESCRIPTION
May resolve #212 

Post-processes the schema returned from the `tap_dbt.client.OPENAPI_URL` to extend types to e.g.:

```json
["string","null"]
```

When a schema has a property with:

```json
"nullable": true
```

Local testing completed OK.