### PR TITLE
fix: Run artifacts records missing account ID and run ID

### DIFF
--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -288,7 +288,7 @@ class RunArtifacts(AccountBasedStream):
         return SinglePagePaginator()
 
     @override
-    def post_process(self, row, context):
+    def post_process(self, row: dict, context: Context) -> dict:
         row["account_id"] = context["account_id"]
         row["run_id"] = context["run_id"]
         return row

--- a/tap_dbt/streams.py
+++ b/tap_dbt/streams.py
@@ -286,3 +286,9 @@ class RunArtifacts(AccountBasedStream):
     @override
     def get_new_paginator(self) -> SinglePagePaginator:
         return SinglePagePaginator()
+
+    @override
+    def post_process(self, row, context):
+        row["account_id"] = context["account_id"]
+        row["run_id"] = context["run_id"]
+        return row


### PR DESCRIPTION
Fixes an issue introduced in #462 by unsetting `state_partitioning_keys` which stopped the SDK automatically merging context with records.

cc @awarwick06